### PR TITLE
feat(scenarios): add new market scenarios for simulation

### DIFF
--- a/scenarios/calm-market.json
+++ b/scenarios/calm-market.json
@@ -1,0 +1,17 @@
+{
+  "scenario_name": "calm-market",
+  "description": "25 days of steady, baseline demand with no shocks. Useful as a control run when comparing against more volatile scenarios.",
+  "base_demand": {"mean": 5, "variance": 2},
+  "events": [
+    {
+      "name": "normal",
+      "start_day": 1,
+      "end_day": 25,
+      "demand_modifier": 1.0,
+      "supply_modifier": 1.0,
+      "lead_time_modifier": 1.0,
+      "price_sensitivity": "normal",
+      "description": "Steady state market"
+    }
+  ]
+}

--- a/scenarios/demo.json
+++ b/scenarios/demo.json
@@ -1,0 +1,37 @@
+{
+  "scenario_name": "demo",
+  "description": "3-day live-demo scenario. Day 1 establishes a normal baseline, day 2 fires a 3x demand spike so the agents react visibly (stockouts, urgent purchase orders, price moves), day 3 returns to normal so the audience can watch recovery.",
+  "base_demand": {"mean": 5, "variance": 2},
+  "events": [
+    {
+      "name": "normal",
+      "start_day": 1,
+      "end_day": 1,
+      "demand_modifier": 1.0,
+      "supply_modifier": 1.0,
+      "lead_time_modifier": 1.0,
+      "price_sensitivity": "normal",
+      "description": "Baseline day — agents establish their default behaviour"
+    },
+    {
+      "name": "demand_spike",
+      "start_day": 2,
+      "end_day": 2,
+      "demand_modifier": 3.0,
+      "supply_modifier": 1.0,
+      "lead_time_modifier": 1.0,
+      "price_sensitivity": "high",
+      "description": "3x demand spike — expect stockouts, expedited POs, and price moves"
+    },
+    {
+      "name": "recovery",
+      "start_day": 3,
+      "end_day": 3,
+      "demand_modifier": 1.0,
+      "supply_modifier": 1.0,
+      "lead_time_modifier": 1.0,
+      "price_sensitivity": "normal",
+      "description": "Back to normal — watch the system catch up and drain backorders"
+    }
+  ]
+}

--- a/scenarios/holiday-rush.json
+++ b/scenarios/holiday-rush.json
@@ -1,0 +1,47 @@
+{
+  "scenario_name": "holiday-rush",
+  "description": "25-day stress test. A black-friday demand spike collides with a chip shortage and a christmas rush, with deliberate overlap on days 18-20 so the engine must multiply concurrent modifiers (not just take the last event).",
+  "base_demand": {"mean": 5, "variance": 2},
+  "events": [
+    {
+      "name": "normal",
+      "start_day": 1,
+      "end_day": 10,
+      "demand_modifier": 1.0,
+      "supply_modifier": 1.0,
+      "lead_time_modifier": 1.0,
+      "price_sensitivity": "normal",
+      "description": "Calm baseline before the holidays"
+    },
+    {
+      "name": "black_friday",
+      "start_day": 11,
+      "end_day": 13,
+      "demand_modifier": 3.0,
+      "supply_modifier": 1.0,
+      "lead_time_modifier": 1.0,
+      "price_sensitivity": "high",
+      "description": "Black Friday demand spike"
+    },
+    {
+      "name": "chip_shortage",
+      "start_day": 14,
+      "end_day": 20,
+      "demand_modifier": 1.5,
+      "supply_modifier": 0.4,
+      "lead_time_modifier": 2.0,
+      "price_sensitivity": "low",
+      "description": "Global chip shortage: suppliers slow, parts scarce"
+    },
+    {
+      "name": "christmas_rush",
+      "start_day": 18,
+      "end_day": 25,
+      "demand_modifier": 2.5,
+      "supply_modifier": 0.6,
+      "lead_time_modifier": 1.0,
+      "price_sensitivity": "high",
+      "description": "Christmas buying surge stacked on top of the shortage"
+    }
+  ]
+}


### PR DESCRIPTION
- Introduced three new scenario files: `calm-market.json`, `demo.json`, and `holiday-rush.json`.
- `calm-market.json` simulates 25 days of steady demand with no shocks, serving as a control run.
- `demo.json` features a 3-day live demo with a demand spike and recovery phase to showcase agent reactions.
- `holiday-rush.json` presents a 25-day stress test combining a Black Friday spike, chip shortage, and Christmas rush, testing the engine's ability to handle concurrent demand and supply modifiers.

These scenarios enhance the simulation capabilities of the turn engine, providing diverse conditions for analysis and testing.